### PR TITLE
feat: auto-generate flow docs

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,37 @@
+name: Update README
+
+on:
+  push:
+    paths:
+      - 'test/**'
+      - 'source/**'
+      - 'build.gradle.kts'
+      - '.github/workflows/update-readme.yml'
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Generate README
+        run: ./gradlew updateReadme
+      - name: Commit changes
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          if git diff --quiet README.md; then
+            echo "No changes to commit"
+          else
+            git add README.md
+            git commit -m "chore: update flow docs"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -170,45 +170,200 @@ FlowLite supports three types of stage transitions:
 * Waiting on multiple events (event with conditional?)
 * History of changes
 
-## Process Example
+## Flow Examples
 
-### Diagram
+<!-- FLOW-DOCS-START -->
+
+### Pizza Order
 
 ```mermaid
 stateDiagram-v2
-    state if_payment_method <<choice>>
-    
-    [*] --> Started
-    Started --> if_payment_method
-    CancellingOrder --> [*]
-    if_payment_method --> InitializingCashPayment: paymentMethod = CASH
-    if_payment_method --> InitializingOnlinePayment: paymentMethod = ONLINE
+    state if_paymentmethod_paymentmethod_cash <<choice>>
+    [*] --> if_paymentmethod_paymentmethod_cash
+    if_paymentmethod_paymentmethod_cash --> InitializingCashPayment: paymentMethod == PaymentMethod.CASH
     InitializingCashPayment: InitializingCashPayment initializeCashPayment()
     InitializingCashPayment --> StartingOrderPreparation: onEvent PaymentConfirmed
-    InitializingCashPayment --> CancellingOrder: onEvent Cancel
-    InitializingOnlinePayment: InitializingOnlinePayment initializeOnlinePayment()
-    InitializingOnlinePayment --> InitializingCashPayment: onEvent SwitchToCashPayment
-    InitializingOnlinePayment --> StartingOrderPreparation: onEvent PaymentCompleted
-    InitializingOnlinePayment --> CancellingOrder: onEvent Cancel 
-    InitializingOnlinePayment --> ExpiringOnlinePayment: onEvent PaymentSessionExpired
-    ExpiringOnlinePayment: ExpiringOnlinePayment handlePaymentExpiration()
-    ExpiringOnlinePayment --> InitializingOnlinePayment: onEvent RetryPayment
-    ExpiringOnlinePayment --> CancellingOrder: onEvent Cancel
     StartingOrderPreparation: StartingOrderPreparation startOrderPreparation()
     StartingOrderPreparation --> InitializingDelivery: onEvent ReadyForDelivery
-     
     InitializingDelivery: InitializingDelivery initializeDelivery()
     InitializingDelivery --> CompletingOrder: onEvent DeliveryCompleted
-    InitializingDelivery --> CancellingOrder: onEvent DeliveryFailed
-    
     CompletingOrder: CompletingOrder completeOrder()
+    InitializingDelivery --> CancellingOrder: onEvent DeliveryFailed
     CancellingOrder: CancellingOrder sendOrderCancellation()
+    InitializingCashPayment --> CancellingOrder: onEvent Cancel
+    if_paymentmethod_paymentmethod_cash --> InitializingOnlinePayment: NOT (paymentMethod == PaymentMethod.CASH)
+    InitializingOnlinePayment: InitializingOnlinePayment initializeOnlinePayment()
+    InitializingOnlinePayment --> StartingOrderPreparation: onEvent PaymentCompleted
+    InitializingOnlinePayment --> InitializingCashPayment: onEvent SwitchToCashPayment
+    InitializingOnlinePayment --> CancellingOrder: onEvent Cancel
+    InitializingOnlinePayment --> ExpiringOnlinePayment: onEvent PaymentSessionExpired
+    ExpiringOnlinePayment --> InitializingOnlinePayment: onEvent RetryPayment
+    ExpiringOnlinePayment --> CancellingOrder: onEvent Cancel
     CompletingOrder --> [*]
+    CancellingOrder --> [*]
+
 ```
 
-### Code
+```kotlin
+fun createPizzaOrderFlow(): Flow<PizzaOrder> {
 
-See examples in [test](test) directory
+    // Define main pizza order flow
+    return FlowBuilder<PizzaOrder>()
+        .condition(
+            predicate = { it.paymentMethod == PaymentMethod.CASH },
+            onTrue = {
+                stage(InitializingCashPayment, ::initializeCashPayment).apply {
+                    waitFor(PaymentConfirmed)
+                        .stage(StartingOrderPreparation, ::startOrderPreparation)
+                        .waitFor(ReadyForDelivery)
+                        .stage(InitializingDelivery, ::initializeDelivery)
+                        .apply {
+                            waitFor(DeliveryCompleted).stage(CompletingOrder, ::completeOrder).end()
+                            waitFor(DeliveryFailed).stage(CancellingOrder, ::sendOrderCancellation).end()
+                        }
+                    waitFor(Cancel).join(CancellingOrder)
+                }
+            },
+            onFalse = {
+                stage(InitializingOnlinePayment, ::initializeOnlinePayment).apply {
+                    waitFor(PaymentCompleted).join(StartingOrderPreparation)
+                    waitFor(SwitchToCashPayment).join(InitializingCashPayment)
+                    waitFor(Cancel).join(CancellingOrder)
+                    waitFor(PaymentSessionExpired).stage(ExpiringOnlinePayment).apply {
+                        waitFor(RetryPayment).join(InitializingOnlinePayment)
+                        waitFor(Cancel).join(CancellingOrder)
+                    }
+                }
+            },
+            description = "paymentMethod == PaymentMethod.CASH"
+        )
+        .build()
+}
+```
+
+
+### Order Confirmation
+
+```mermaid
+stateDiagram-v2
+    [*] --> InitializingConfirmation
+    InitializingConfirmation: InitializingConfirmation initializeOrderConfirmation()
+    InitializingConfirmation --> WaitingForConfirmation
+    WaitingForConfirmation --> RemovingFromConfirmationQueue: onEvent ConfirmedDigitally
+    RemovingFromConfirmationQueue: RemovingFromConfirmationQueue removeFromConfirmationQueue()
+    RemovingFromConfirmationQueue --> InformingCustomer
+    InformingCustomer: InformingCustomer informCustomer()
+    WaitingForConfirmation --> InformingCustomer: onEvent ConfirmedPhysically
+    InformingCustomer --> [*]
+
+```
+
+```kotlin
+fun createOrderConfirmationFlow(): Flow<OrderConfirmation> {
+    return FlowBuilder<OrderConfirmation>()
+        .stage(InitializingConfirmation, ::initializeOrderConfirmation)
+        .stage(WaitingForConfirmation)
+        .apply {
+            waitFor(OrderConfirmationEvent.ConfirmedDigitally)
+                .stage(RemovingFromConfirmationQueue, ::removeFromConfirmationQueue)
+                .stage(InformingCustomer, ::informCustomer)
+            waitFor(ConfirmedPhysically).join(InformingCustomer)
+        }
+        .end()
+        .build()
+}
+```
+
+
+### Employee Onboarding
+
+```mermaid
+stateDiagram-v2
+    state if_isonboardingautomated <<choice>>
+    state if_isexecutiverole_issecurityclearancerequired <<choice>>
+    state if_issecurityclearancerequired <<choice>>
+    state if_isfullonboardingrequired <<choice>>
+    state if_isexecutiverole_issecurityclearancerequired_2 <<choice>>
+    [*] --> if_isonboardingautomated
+    if_isonboardingautomated --> CreateUserInSystem: isOnboardingAutomated
+    CreateUserInSystem: CreateUserInSystem createUserInSystem()
+    CreateUserInSystem --> if_isexecutiverole_issecurityclearancerequired
+    if_isexecutiverole_issecurityclearancerequired --> UpdateSecurityClearanceLevels: isExecutiveRole || isSecurityClearanceRequired
+    UpdateSecurityClearanceLevels: UpdateSecurityClearanceLevels updateSecurityClearanceLevels()
+    UpdateSecurityClearanceLevels --> if_issecurityclearancerequired
+    if_issecurityclearancerequired --> if_isfullonboardingrequired: isSecurityClearanceRequired
+    if_isfullonboardingrequired --> SetDepartmentAccess: isFullOnboardingRequired
+    SetDepartmentAccess: SetDepartmentAccess setDepartmentAccess()
+    SetDepartmentAccess --> GenerateEmployeeDocuments
+    GenerateEmployeeDocuments: GenerateEmployeeDocuments generateEmployeeDocuments()
+    GenerateEmployeeDocuments --> SendContractForSigning
+    SendContractForSigning: SendContractForSigning sendContractForSigning()
+    SendContractForSigning --> WaitingForEmployeeDocumentsSigned
+    WaitingForEmployeeDocumentsSigned --> WaitingForContractSigned: onEvent EmployeeDocumentsSigned
+    WaitingForContractSigned --> if_isexecutiverole_issecurityclearancerequired_2: onEvent ContractSigned
+    if_isexecutiverole_issecurityclearancerequired_2 --> ActivateSpecializedEmployee: isExecutiveRole || isSecurityClearanceRequired
+    ActivateSpecializedEmployee: ActivateSpecializedEmployee activateEmployee()
+    ActivateSpecializedEmployee --> UpdateStatusInHRSystem
+    UpdateStatusInHRSystem: UpdateStatusInHRSystem updateStatusInHRSystem()
+    if_isexecutiverole_issecurityclearancerequired_2 --> WaitingForOnboardingCompletion: NOT (isExecutiveRole || isSecurityClearanceRequired)
+    WaitingForOnboardingCompletion --> UpdateStatusInHRSystem: onEvent OnboardingComplete
+    if_isfullonboardingrequired --> GenerateEmployeeDocuments: NOT (isFullOnboardingRequired)
+    if_issecurityclearancerequired --> WaitingForContractSigned: NOT (isSecurityClearanceRequired)
+    if_isexecutiverole_issecurityclearancerequired --> ActivateStandardEmployee: NOT (isExecutiveRole || isSecurityClearanceRequired)
+    ActivateStandardEmployee: ActivateStandardEmployee activateEmployee()
+    ActivateStandardEmployee --> GenerateEmployeeDocuments
+    if_isonboardingautomated --> WaitingForContractSigned: NOT (isOnboardingAutomated)
+    UpdateStatusInHRSystem --> [*]
+
+```
+
+```kotlin
+fun createEmployeeOnboardingFlow(): Flow<EmployeeOnboarding> {
+    return FlowBuilder<EmployeeOnboarding>()
+        .condition(
+            predicate = { it.isOnboardingAutomated },
+            description = "isOnboardingAutomated",
+            onTrue = {
+                // Automated path
+                stage(CreateUserInSystem, ::createUserInSystem)
+                    .condition( { it.isExecutiveRole || it.isSecurityClearanceRequired },
+                        description = "isExecutiveRole || isSecurityClearanceRequired",
+                        onFalse = {
+                            stage(ActivateStandardEmployee, ::activateEmployee)
+                                .stage(GenerateEmployeeDocuments, ::generateEmployeeDocuments)
+                                .stage(SendContractForSigning, ::sendContractForSigning)
+                                .stage(WaitingForEmployeeDocumentsSigned)
+                                .waitFor(EmployeeDocumentsSigned)
+                                .stage(WaitingForContractSigned)
+                                .waitFor(ContractSigned, condition = {it.isContractSigned})
+                                .condition({ it.isExecutiveRole || it.isSecurityClearanceRequired },
+                                    description = "isExecutiveRole || isSecurityClearanceRequired",
+                                    onTrue = {
+                                        stage(ActivateSpecializedEmployee, ::activateEmployee)
+                                            .stage(UpdateStatusInHRSystem, ::updateStatusInHRSystem) },
+                                    onFalse = {
+                                        stage(WaitingForOnboardingCompletion).waitFor(OnboardingComplete).join(UpdateStatusInHRSystem)}
+                                ) },
+                        onTrue = {
+                            stage(UpdateSecurityClearanceLevels, ::updateSecurityClearanceLevels)
+                                .condition( {it.isSecurityClearanceRequired },
+                                    description = "isSecurityClearanceRequired",
+                                    onTrue = {condition ({it.isFullOnboardingRequired},
+                                        description = "isFullOnboardingRequired",
+                                        onTrue = {stage(SetDepartmentAccess, ::setDepartmentAccess).join(GenerateEmployeeDocuments)},
+                                        onFalse = {join(GenerateEmployeeDocuments)})},
+                                    onFalse = {join(WaitingForContractSigned)})
+                        })
+            },
+            onFalse = {
+                // Manual path
+                join(WaitingForContractSigned)
+            }
+        )
+        .build()
+}
+```
+<!-- FLOW-DOCS-END -->
 
 ## Parallel Execution (Idea)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,11 @@ kotlin {
     jvmToolchain(21)
 }
 
+tasks.register<JavaExec>("updateReadme") {
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("io.flowlite.test.ReadmeUpdaterKt")
+}
+
 publishing {
     publications {
         create<MavenPublication>("maven") {

--- a/source/flowApi.kt
+++ b/source/flowApi.kt
@@ -68,7 +68,7 @@ class FlowBuilder<T : Any> {
         predicate: (item: T) -> Boolean,
         onTrue: FlowBuilder<T>.() -> Unit,
         onFalse: FlowBuilder<T>.() -> Unit,
-        description: String? = null
+        description: String
     ): FlowBuilder<T> {
         initialCondition = createConditionHandler(predicate, onTrue, onFalse, description)
         return this
@@ -85,7 +85,7 @@ class FlowBuilder<T : Any> {
         predicate: (item: T) -> Boolean,
         onTrue: FlowBuilder<T>.() -> Unit,
         onFalse: FlowBuilder<T>.() -> Unit,
-        description: String?
+        description: String
     ): ConditionHandler<T> {
         // Create both branch builders
         val trueBranch = FlowBuilder<T>().apply(onTrue)
@@ -158,7 +158,7 @@ data class ConditionHandler<T : Any>(
     val trueCondition: ConditionHandler<T>?,
     val falseStage: Stage?,
     val falseCondition: ConditionHandler<T>?,
-    val description: String? = null,
+    val description: String,
 )
 
 data class EventHandler<T : Any>(
@@ -187,7 +187,7 @@ class StageBuilder<T : Any>(
         predicate: (item: T) -> Boolean,
         onTrue: FlowBuilder<T>.() -> Unit,
         onFalse: FlowBuilder<T>.() -> Unit,
-        description: String? = null
+        description: String
     ): FlowBuilder<T> {
         if (stageDefinition.hasConflictingTransitions(TransitionType.CONDITION)) {
             throw FlowDefinitionException("Stage ${stageDefinition.stage} already has transitions defined: ${stageDefinition.getExistingTransitions()}. Use only one of: stage(), onEvent(), or condition().")
@@ -231,7 +231,7 @@ class EventBuilder<T : Any>(
         predicate: (item: T) -> Boolean,
         onTrue: FlowBuilder<T>.() -> Unit,
         onFalse: FlowBuilder<T>.() -> Unit,
-        description: String? = null
+        description: String
     ): FlowBuilder<T> {
         stageBuilder.stageDefinition.eventHandlers[event] = EventHandler(event, null,
             stageBuilder.flowBuilder.createConditionHandler(predicate, onTrue, onFalse, description))

--- a/test/OrderConfirmationTest.kt
+++ b/test/OrderConfirmationTest.kt
@@ -58,6 +58,7 @@ fun informCustomer(confirmation: OrderConfirmation): OrderConfirmation {
     return confirmation.copy(stage = InformingCustomer, isCustomerInformed = true)
 }
 
+// FLOW-DEFINITION-START
 fun createOrderConfirmationFlow(): Flow<OrderConfirmation> {
     return FlowBuilder<OrderConfirmation>()
         .stage(InitializingConfirmation, ::initializeOrderConfirmation)
@@ -71,6 +72,7 @@ fun createOrderConfirmationFlow(): Flow<OrderConfirmation> {
         .end()
         .build()
 }
+// FLOW-DEFINITION-END
 
 /**
  * Tests for the order confirmation flow definition and diagram generation.

--- a/test/ReadmeUpdater.kt
+++ b/test/ReadmeUpdater.kt
@@ -1,0 +1,71 @@
+package io.flowlite.test
+
+import io.flowlite.api.Flow
+import io.flowlite.api.MermaidGenerator
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readLines
+import kotlin.io.path.readText
+
+/** Updates README.md with flow diagrams and code snippets extracted from test files. */
+fun main() {
+    val testDir = Path.of("test")
+    val generator = MermaidGenerator()
+    val flows = mutableListOf<FlowDoc>()
+
+    Files.list(testDir).use { paths ->
+        paths.filter { it.toString().endsWith("Test.kt") }.forEach { path ->
+            val lines = path.readLines()
+            val start = lines.indexOfFirst { it.contains("FLOW-DEFINITION-START") }
+            val end = lines.indexOfFirst { it.contains("FLOW-DEFINITION-END") }
+            if (start != -1 && end != -1 && end > start) {
+                val codeLines = lines.subList(start + 1, end)
+                val code = codeLines.joinToString(System.lineSeparator())
+                val funName = Regex("""fun\s+(\w+)""").find(code)?.groupValues?.get(1) ?: return@forEach
+                val fileClass = path.fileName.toString().substringBeforeLast('.')
+                    .replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() } + "Kt"
+                val fqcn = "io.flowlite.test.$fileClass"
+                val clazz = Class.forName(fqcn)
+                val method = clazz.getDeclaredMethod(funName)
+                @Suppress("UNCHECKED_CAST")
+                val flow = method.invoke(null) as Flow<Any>
+                val flowId = funName.removePrefix("create").removeSuffix("Flow")
+                    .replace(Regex("([a-z])([A-Z])"), "$1-$2").lowercase()
+                val diagram = generator.generateDiagram(flowId, flow)
+                flows += FlowDoc(title = toTitle(flowId), diagram = diagram, code = code)
+            }
+        }
+    }
+
+    val readmePath = Path.of("README.md")
+    val startMarker = "<!-- FLOW-DOCS-START -->"
+    val endMarker = "<!-- FLOW-DOCS-END -->"
+    val content = readmePath.readText()
+    val startIdx = content.indexOf(startMarker)
+    val endIdx = content.indexOf(endMarker)
+    if (startIdx == -1 || endIdx == -1 || endIdx < startIdx) {
+        println("README markers not found")
+        return
+    }
+    val before = content.substring(0, startIdx + startMarker.length)
+    val after = content.substring(endIdx)
+    val newline = System.lineSeparator()
+    val builder = StringBuilder()
+    flows.forEach { doc ->
+        builder.append(newline).append(newline).append("### ").append(doc.title).append(newline).append(newline)
+        builder.append("```mermaid").append(newline).append(doc.diagram).append(newline).append("```").append(newline).append(newline)
+        builder.append("```kotlin").append(newline).append(doc.code).append(newline).append("```").append(newline)
+    }
+    val newContent = before + builder.toString() + after
+    if (newContent != content) {
+        Files.writeString(readmePath, newContent)
+    } else {
+        println("README is up to date")
+    }
+}
+
+data class FlowDoc(val title: String, val diagram: String, val code: String)
+
+private fun toTitle(id: String): String =
+    id.split("-").joinToString(" ") { it.replaceFirstChar { c -> c.uppercase() } }
+

--- a/test/employeeOnboardingFlowTest.kt
+++ b/test/employeeOnboardingFlowTest.kt
@@ -110,7 +110,7 @@ fun updateStatusInHRSystem(employee: EmployeeOnboarding): EmployeeOnboarding {
 }
 
 // --- Flow Definition ---
-
+// FLOW-DEFINITION-START
 fun createEmployeeOnboardingFlow(): Flow<EmployeeOnboarding> {
     return FlowBuilder<EmployeeOnboarding>()
         .condition(
@@ -155,3 +155,4 @@ fun createEmployeeOnboardingFlow(): Flow<EmployeeOnboarding> {
         )
         .build()
 }
+// FLOW-DEFINITION-END

--- a/test/pizzaOrderFlowTest.kt
+++ b/test/pizzaOrderFlowTest.kt
@@ -48,7 +48,7 @@ class PizzaOrderFlowTest : BehaviorSpec({
             }
 
             then("should have initial condition") {
-                diagram shouldContain "[*] --> if_initial"
+                diagram shouldContain "[*] --> if_paymentmethod_paymentmethod_cash"
             }
 
             then("should contain all stages") {
@@ -98,9 +98,9 @@ class PizzaOrderFlowTest : BehaviorSpec({
             }
 
             then("should include condition descriptions on transitions") {
-                diagram shouldContain "state if_initial <<choice>>"
-                diagram shouldContain "if_initial --> $InitializingCashPayment: paymentMethod == PaymentMethod.CASH"
-                diagram shouldContain "if_initial --> $InitializingOnlinePayment: NOT (paymentMethod == PaymentMethod.CASH)"
+                diagram shouldContain "state if_paymentmethod_paymentmethod_cash <<choice>>"
+                diagram shouldContain "if_paymentmethod_paymentmethod_cash --> $InitializingCashPayment: paymentMethod == PaymentMethod.CASH"
+                diagram shouldContain "if_paymentmethod_paymentmethod_cash --> $InitializingOnlinePayment: NOT (paymentMethod == PaymentMethod.CASH)"
             }
         }
     }
@@ -163,6 +163,7 @@ fun completeOrder(order: PizzaOrder): PizzaOrder = order
 fun sendOrderCancellation(order: PizzaOrder): PizzaOrder = order
 
 // --- Flow Definition ---
+// FLOW-DEFINITION-START
 fun createPizzaOrderFlow(): Flow<PizzaOrder> {
 
     // Define main pizza order flow
@@ -197,6 +198,7 @@ fun createPizzaOrderFlow(): Flow<PizzaOrder> {
         )
         .build()
 }
+// FLOW-DEFINITION-END
 
 /** Simple in-memory state persister for testing purposes */
 class InMemoryStatePersister<T : Any> : StatePersister<T> {


### PR DESCRIPTION
## Summary
- remove hash-based condition node names
- skip README commits when unchanged
- require condition descriptions and name diagram nodes after them, adding numeric suffixes for duplicates

## Testing
- `./gradlew test`
- `./gradlew updateReadme`


------
https://chatgpt.com/codex/tasks/task_e_68a74d40f58c833283695ea13b4c8379